### PR TITLE
controllers: move regions to the least populated up-to-date regionserver

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -52,7 +52,6 @@ import (
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
-var ghClient *mock.MockClient
 var ghAdmin *mock.MockAdminClient
 
 func TestAPIs(t *testing.T) {
@@ -125,7 +124,6 @@ var _ = BeforeSuite(func(done Done) {
 	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
 	gomockCtrl := gomock.NewController(GinkgoT())
 	defer gomockCtrl.Finish()
-	ghClient = mock.NewMockClient(gomockCtrl)
 	ghAdmin = mock.NewMockAdminClient(gomockCtrl)
 	ghAdmin.EXPECT().ClusterStatus().AnyTimes().Return(&pb.ClusterStatus{}, nil)
 	ghAdmin.EXPECT().SetBalancer(gomock.Any()).AnyTimes()
@@ -152,11 +150,10 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&HBaseReconciler{
-		Client:   k8sManager.GetClient(),
-		Log:      ctrl.Log.WithName("controllers").WithName("HBase"),
-		Scheme:   k8sManager.GetScheme(),
-		GhClient: ghClient,
-		GhAdmin:  ghAdmin,
+		Client:  k8sManager.GetClient(),
+		Log:     ctrl.Log.WithName("controllers").WithName("HBase"),
+		Scheme:  k8sManager.GetScheme(),
+		GhAdmin: ghAdmin,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -70,11 +70,10 @@ func main() {
 	}
 
 	if err = (&controllers.HBaseReconciler{
-		Client:   mgr.GetClient(),
-		Log:      ctrl.Log.WithName("controllers").WithName("HBase"),
-		Scheme:   mgr.GetScheme(),
-		GhClient: gohbase.NewClient(zkQuorum),
-		GhAdmin:  gohbase.NewAdminClient(zkQuorum),
+		Client:  mgr.GetClient(),
+		Log:     ctrl.Log.WithName("controllers").WithName("HBase"),
+		Scheme:  mgr.GetScheme(),
+		GhAdmin: gohbase.NewAdminClient(zkQuorum),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HBase")
 		os.Exit(1)


### PR DESCRIPTION
Instead of relying on HBase Master to assign regions during rolling restart,
use our insider knowledge to decide on the target based on the following
criteria:
- Move to only up-to-date regionserver to minimize reassignment
- Move to the regionserver with the least number of region