### PR TITLE
Allow configuring controller namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ Installation instructions:
 4. run `kubectl apply -f config/samples/hbase_v1_hbase.yaml` to tell the operator what to deploy.
 5. now you can go and focus on actual features of your product
 
-The perator and HBase must be deployed to the same namespace, which defaults to `hbase`.
+The operator and HBase must be deployed to the same namespace, which defaults to `hbase`.

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ Installation instructions:
 4. run `kubectl apply -f config/samples/hbase_v1_hbase.yaml` to tell the operator what to deploy.
 5. now you can go and focus on actual features of your product
 
-It's expected that operator and HBase will be deployed in `hbase` namespace.
+The perator and HBase must be deployed to the same namespace, which defaults to `hbase`.

--- a/main.go
+++ b/main.go
@@ -49,19 +49,22 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var zkQuorum string
+	var namespace string
 	flag.StringVar(&zkQuorum, "zkquorum", "localhost:2181",
 		"Comma-separated list of zookeeper addresses.")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&namespace, "namespace", "hbase", "The namespace to watch for resource definitions.")
+
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
-		Namespace:          "hbase",
+		Namespace:          namespace,
 		MetricsBindAddress: metricsAddr,
 	})
 	if err != nil {


### PR DESCRIPTION
Allow configuring namespace to watch by controller. This is useful for spinning up multiple hbase clusters across different namespaces.