### PR TITLE
controller: Make it so that last-applied-configuration isn't hashed

### DIFF
--- a/controllers/hbase_controller.go
+++ b/controllers/hbase_controller.go
@@ -641,8 +641,8 @@ const (
 )
 
 var (
-	ignoreTemplateMetadataAnnotations = map[string]bool{
-		"kubectl.kubernetes.io/last-applied-configuration": true,
+	ignoreTemplateMetadataAnnotations = map[string]struct{}{
+		"kubectl.kubernetes.io/last-applied-configuration": struct{}{},
 	}
 )
 


### PR DESCRIPTION
The annotation kubectl.kubernetes.io/last-applied-configuration
holds information about replica count. Including this annotation
makes it so that scaling operations (such as increasing or
decreasing regionserver replica count) will erroneously trigger
complete redeployment due to differing hash. Filter this annotation
out during calculation of statefuleset hash.