### PR TITLE
Fix pods rolling restart when number of replicas changed

### DIFF
--- a/controllers/hbase_controller.go
+++ b/controllers/hbase_controller.go
@@ -138,7 +138,7 @@ func (r *HBaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, err
 	}
 	if masterUpdated {
-		log.Info("HBase Master StatefulSet updated, reconsiling again")
+		log.Info("HBase Master StatefulSet updated, reconciling again")
 		return ctrl.Result{Requeue: true}, nil
 	}
 	log.Info("HBase Master StatefulSet is in sync")
@@ -164,7 +164,7 @@ func (r *HBaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, fmt.Errorf("failed to get regions in transition: %v", err)
 	}
 	if rit != 0 {
-		log.Info("There are regions in transition, wait and restart reconsiling", "regions", rit)
+		log.Info("There are regions in transition, wait and restart reconciling", "regions", rit)
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 	log.Info("There are no regions in transition")
@@ -567,7 +567,7 @@ func (r *HBaseReconciler) ensureStatefulSetPods(ctx context.Context, sts *appsv1
 		return false, r.Delete(ctx, p)
 	}
 
-	r.Log.Info("pods are up to date", "StatefulSet" ,sts.Name)
+	r.Log.Info("pods are up to date", "StatefulSet", sts.Name)
 	// all is perfect, ensured
 	return true, nil
 
@@ -600,7 +600,8 @@ func (r *HBaseReconciler) ensureStatefulSet(hb *hbasev1.HBase,
 	r.Log.Info("StatefulSet reconciliation",
 		"name", stsName,
 		"revision is up to date", actualRevision == expectedRevision,
-		"expected replica count", *actual.Spec.Replicas == *expected.Spec.Replicas)
+		"expected replicas", *actual.Spec.Replicas,
+		"actual replicas", *expected.Spec.Replicas)
 
 	if *actual.Spec.Replicas != *expected.Spec.Replicas || actualRevision != expectedRevision {
 		// Update StatefulSet to expected configuration

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -236,7 +236,7 @@ var _ = Describe("HBase controller", func() {
 			getExistingSts("hbasemaster", namespace, createdMasterStatefulSet)
 
 			By("By checking master statefulset has correct number of replicas")
-			Ω(hb.Spec.MasterSpec.Count).Should(Equal(int32(2)))
+			Ω(*createdMasterStatefulSet.Spec.Replicas).Should(Equal(int32(2)))
 
 			By("By checking master statefulset has mounted correct confgmap")
 			vs := createdMasterStatefulSet.Spec.Template.Spec.Volumes
@@ -263,7 +263,7 @@ var _ = Describe("HBase controller", func() {
 			getExistingSts("regionserver", namespace, createdRegionServerStatefulSet)
 
 			By("By checking regionserver statefulset has correct number of replicas")
-			Ω(hb.Spec.RegionServerSpec.Count).Should(Equal(int32(3)))
+			Ω(*createdRegionServerStatefulSet.Spec.Replicas).Should(Equal(int32(3)))
 
 			By("By checking regionserver statefulset has mounted correct confgmap")
 			vs = createdRegionServerStatefulSet.Spec.Template.Spec.Volumes


### PR DESCRIPTION
 Annotation change cause changes of controller-hash-revision of the StatefulSet. It caused unnecessary restarts of all pods.

"kubectl.kubernetes.io/last-applied-configuration" is updated with every update of the HBase CRD including just replicas count update. It should not be included into pod template metadata to avoid unnecessary pods restart.

ensureStatefulSet function logging is more clear.

Minor changes with logging messages and test fixes.